### PR TITLE
Fixing Miro API throttling on object selection

### DIFF
--- a/react-app/src/app.tsx
+++ b/react-app/src/app.tsx
@@ -8,8 +8,8 @@ export default function App() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const handler = async () => {
-      const selection = await miro.board.getSelection();
+    const handler = async (event: { items: any[] }) => {
+      const selection = event.items
       if (selection.length === 1) {
         const id = selection[0].id;
 


### PR DESCRIPTION
*Description of changes:*

The Object Selection event passes a list of selected objects as an argument to the event handler.
We can use this argument rather than calling an API, and thus save API calls limit in order to avoid API throttling event if a user actively selects/deselects objects on a board.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.